### PR TITLE
Hide horizontal scrollbars but still allow scrolling

### DIFF
--- a/app/assets/stylesheets/objects/_post.sass
+++ b/app/assets/stylesheets/objects/_post.sass
@@ -54,6 +54,7 @@
       color: $dark-gray
   .highlight
     margin-bottom: 20px
+    overflow-y: hidden
   code, pre
     font-family: $code-font
     background-color: $code-background
@@ -74,6 +75,7 @@
     display: block
     font-size: $code-font-size
     overflow-x: scroll
+    overflow-y: auto
     padding: $code-padding
   ol, ul
     list-style-position: inside


### PR DESCRIPTION
Scrollbars are hidden by default in OSX, so this should make no difference for them
For other systems, they are plain ugly, so it might be better to hide them
Horizontal scroll is still possible

Solution was based on the answer given here:
http://stackoverflow.com/questions/5820304/hidden-scrollbars-in-firefox-allows-scrolling-but-just-no-scrollbar
