### PR TITLE
Fixes code font size

### DIFF
--- a/app/assets/stylesheets/variables.sass
+++ b/app/assets/stylesheets/variables.sass
@@ -45,7 +45,7 @@ $post-font-size: 24px
 $small-font-size: 18px
 $nav-font-size: 14px
 $saying-size: 20px
-$code-font-size: $post-font-size * 0.80
+$code-font-size: $post-font-size * 0.70
 $inline-code-font-size: $post-font-size * 0.70
 
 // sizes


### PR DESCRIPTION
Font size for code blocks was too big (24px, with line height 24px as well). Looked too bloated
