### PR TITLE
Check for rvm and .ruby-version

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-rvm install $(cat .ruby-version)
+
+if hash rvm 2>/dev/null && -f .ruby-version; then
+  rvm install $(cat .ruby-version)
+fi
 bundle install
 bundle exec rake db:create
 bundle exec rake db:setup


### PR DESCRIPTION
Before trying to use rvm to install the ruby version defined at
.ruby-version, check to see if it is possible to complete this command.