### PR TITLE
Adds caching on two critical sections

### DIFF
--- a/Procfile.production
+++ b/Procfile.production
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+cache: memcached -v

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,5 +1,6 @@
   class Admin::PostsController < Admin::ApplicationController
     decorates_assigned :posts, :post
+    after_action :invalidate_cache, only: %i(create update)
 
     def index
       @drafts = current_user.posts.unpublished
@@ -61,5 +62,9 @@
 
     def post_params
       params.require(:post).permit(:title, :body, :extra_tags, tag_list: [], hero_attributes: [:id, :image, :remove_image])
+    end
+
+    def invalidate_cache
+      Rails.cache.delete('search_tags')
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,8 +14,8 @@ class ApplicationController < ActionController::Base
   helper_method :admin_controller?
 
   def load_tags
-    @all_tags ||= Post.all_tags.
-                  select { |tag| Post.published.tagged_with(tag).any? }.
-                  sort_by { |tag| Post::PRIMARY_TAGS.include?(tag.name.to_sym) ? 0 : 1 }.first(10)
+    @all_tags ||= Rails.cache.fetch('search_tags') do
+      Post.published_tags.sort_by { |tag| Post::PRIMARY_TAGS.include?(tag.name.to_sym) ? 0 : 1 }.first(10)
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -71,6 +71,10 @@ class Post < ActiveRecord::Base
     hero && hero.image && hero.image.url.present?
   end
 
+  def self.published_tags
+    all_tags.select { |tag| Post.published.tagged_with(tag).any? }
+  end
+
   private
 
   def set_extra_tags

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -4,11 +4,8 @@ html.Theme lang="en"
   head
     = render '/layouts/meta'
     = csrf_meta_tags
-
     = stylesheet_link_tag    "application"
-
     = favicon_link_tag 'favicon.ico'
-
     = auto_discovery_link_tag :rss, feed_url(:rss), title: 'Subvisual Blog'
 
     - if Rails.env.production?
@@ -32,7 +29,6 @@ html.Theme lang="en"
     javascript:
       try{Typekit.load();}catch(e){}
     = javascript_include_tag "application"
-
     - if content_for?(:page_script)
       = yield(:page_script)
 

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -8,22 +8,23 @@
 
 = render 'post_hero', post: post
 
-.u-xSmallThenSmallMargin
+- cache [post, 'show']
+  .u-xSmallThenSmallMargin
 
-.PostWidthConstrainer
-  = render 'shared/tag_list', tag_list: post.tag_list
-.u-smallThenDefaultMargin
+  .PostWidthConstrainer
+    = render 'shared/tag_list', tag_list: post.tag_list
+  .u-smallThenDefaultMargin
 
-.Post
-  .Post-body = post.processed_body
+  .Post
+    .Post-body = post.processed_body
 
-.PostWidthConstrainer
-  .u-defaultThenLargeMargin
-  .Separator.Separator--subvisual
-  .u-defaultThenLargeMargin
+  .PostWidthConstrainer
+    .u-defaultThenLargeMargin
+    .Separator.Separator--subvisual
+    .u-defaultThenLargeMargin
 
-  = render 'author_bio', author: post.author
-  .u-defaultThenLargeMargin
+    = render 'author_bio', author: post.author
+    .u-defaultThenLargeMargin
 
 = render 'related_posts', post: post
 .u-largeMargin

--- a/config/initializers/cache.rb
+++ b/config/initializers/cache.rb
@@ -1,0 +1,1 @@
+Rails.application.config.cache_store = :mem_cache_store, 'localhost:11211'


### PR DESCRIPTION
Adds caching on two critical sections
    
* The PostsController#show view accounts for 54% of total app time. This is an attempt to speed it up by caching the main content
* The search tags require a complex query to fetch only the tags for which there are published posts (to exclude drafts). Since this remains static for a long time (it only changes when we edit or add new posts), caching it can give a good performance boost to the index page as well
