### PR TITLE
Write posts in markdown files, Jekyll style

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :test do
   gem 'database_cleaner', '1.0.1', require: false
   gem 'elasticsearch-extensions'
   gem 'factory_girl_rails', '~> 4.0', require: false
+  gem 'fakefs', require: 'fakefs/safe'
   gem 'faker', require: false
   gem 'simplecov', require: false
   gem 'rspec-html-matchers', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    fakefs (0.6.7)
     faker (1.4.3)
       i18n (~> 0.5)
     faraday (0.9.1)
@@ -395,6 +396,7 @@ DEPENDENCIES
   elasticsearch-model
   elasticsearch-rails
   factory_girl_rails (~> 4.0)
+  fakefs
   faker
   foreman
   headquarters

--- a/app/gb-blog/services/post_file_importer.rb
+++ b/app/gb-blog/services/post_file_importer.rb
@@ -1,0 +1,21 @@
+module Services
+  class PostFileImporter
+    POSTS_DIR = Rails.root.join('posts')
+
+    def process
+      all_files.each do |file|
+        PostFile.import(file)
+        import_file(file)
+      end
+    end
+
+
+    private
+
+    def all_files
+      @all_files ||= Dir.glob(POSTS_DIR.join('*.md'))
+    end
+
+    attr_reader :all_files
+  end
+end

--- a/app/gb-blog/services/post_file_importer.rb
+++ b/app/gb-blog/services/post_file_importer.rb
@@ -2,20 +2,17 @@ module Services
   class PostFileImporter
     POSTS_DIR = Rails.root.join('posts')
 
-    def process
+    def import
+      binding.pry
       all_files.each do |file|
         PostFile.import(file)
-        import_file(file)
       end
     end
-
 
     private
 
     def all_files
       @all_files ||= Dir.glob(POSTS_DIR.join('*.md'))
     end
-
-    attr_reader :all_files
   end
 end

--- a/app/gb-blog/services/post_file_importer.rb
+++ b/app/gb-blog/services/post_file_importer.rb
@@ -3,7 +3,6 @@ module Services
     POSTS_DIR = Rails.root.join('posts')
 
     def import
-      binding.pry
       all_files.each do |file|
         PostFile.import(file)
       end

--- a/app/models/post_file.rb
+++ b/app/models/post_file.rb
@@ -1,0 +1,36 @@
+class PostFile < ActiveRecord::Base
+  belongs_to :post
+
+  validates :filename, presence: true
+
+  def metadata
+    @metadata ||= YAML.load_file(filename)
+  end
+
+  def data
+    {
+      title: metadata['title'],
+      tag_list: metadata['tags'],
+      author: author,
+      body: body
+    }
+  end
+
+  def author
+    User.from_full_name(metadata['author'])
+  end
+
+  def body
+    @body ||= File.read(Rails.root.join(filename)).gsub(/^\s*---(.*?)---\s/m, "")
+  end
+
+  def self.import(file)
+    post_file = where(filename: file).first_or_create
+
+    if File.mtime(post_file.filename) > post_file.updated_at
+      post_file.touch
+    end
+
+    post_file
+  end
+end

--- a/app/models/post_file.rb
+++ b/app/models/post_file.rb
@@ -2,15 +2,18 @@ class PostFile < ActiveRecord::Base
   belongs_to :post
 
   validates :filename, presence: true
+  validates_associated :post
+
+  before_save :update_post
 
   def metadata
-    @metadata ||= YAML.load_file(filename)
+    @metadata ||= YAML.load_file(filename) || {}
   end
 
   def data
     {
       title: metadata['title'],
-      tag_list: metadata['tags'],
+      tag_list: (metadata['tags'] || '').downcase,
       author: author,
       body: body
     }
@@ -25,12 +28,17 @@ class PostFile < ActiveRecord::Base
   end
 
   def self.import(file)
-    post_file = where(filename: file).first_or_create
+    where(filename: file).first_or_initialize.tap(&:save)
+  end
 
-    if File.mtime(post_file.filename) > post_file.updated_at
-      post_file.touch
-    end
+  def update_post
+    file_timestamp = File.mtime(filename)
+    return if last_file_timestamp && last_file_timestamp >= file_timestamp
 
-    post_file
+    build_post unless post
+    post.tag_list = data[:tags]
+    post.update(data)
+
+    assign_attributes post: post, last_file_timestamp: file_timestamp
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,9 @@ class User < ActiveRecord::Base
   def name=(name)
     self.first_name, self.last_name = name.split(' ', 2)
   end
+
+  def self.from_full_name(name)
+    first_name, last_name = name.split(' ')
+    where('first_name ILIKE ? and last_name ILIKE ?', "%#{first_name}%", "%#{last_name}%").first
+  end
 end

--- a/db/migrate/20150728131848_create_post_files_table.rb
+++ b/db/migrate/20150728131848_create_post_files_table.rb
@@ -1,0 +1,9 @@
+class CreatePostFilesTable < ActiveRecord::Migration
+  def change
+    create_table :post_files do |t|
+      t.string :filename, null: false
+      t.references :post
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150728152645_add_last_file_timestamp_to_post_files.rb
+++ b/db/migrate/20150728152645_add_last_file_timestamp_to_post_files.rb
@@ -1,0 +1,5 @@
+class AddLastFileTimestampToPostFiles < ActiveRecord::Migration
+  def change
+    add_column :post_files, :last_file_timestamp, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,10 +17,11 @@ ActiveRecord::Schema.define(version: 20150729010027) do
   enable_extension "plpgsql"
 
   create_table "post_files", force: :cascade do |t|
-    t.string   "filename",   null: false
+    t.string   "filename",            null: false
     t.integer  "post_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "last_file_timestamp"
   end
 
   create_table "post_images", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,13 @@ ActiveRecord::Schema.define(version: 20150729010027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "post_files", force: :cascade do |t|
+    t.string   "filename",   null: false
+    t.integer  "post_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "post_images", force: :cascade do |t|
     t.string  "image"
     t.integer "post_id"

--- a/lib/tasks/posts.rake
+++ b/lib/tasks/posts.rake
@@ -1,0 +1,5 @@
+namespace :posts do
+  task import: :environment do
+    Services::PostFileImporter.new.import
+  end
+end

--- a/posts/20150101_a_new_hope.md
+++ b/posts/20150101_a_new_hope.md
@@ -1,0 +1,9 @@
+---
+title: A new hope
+tags: General
+author: Miguel Palhas
+---
+
+# OMG
+
+It's working

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,6 +17,8 @@ FactoryGirl.define do
   end
 
   factory :user do
+    first_name { Faker::Internet.name.split(' ').first }
+    last_name { Faker::Internet.name.split(' ').last }
     email { Faker::Internet.email }
     password { Faker::Internet.password }
   end

--- a/spec/models/post_file_spec.rb
+++ b/spec/models/post_file_spec.rb
@@ -2,22 +2,29 @@ require 'spec_helper'
 
 describe PostFile do
 
-  def mock_post_file(date: nil)
+  def mock_post_file(mtime: nil, title: nil, author: nil, body: nil, tags: nil)
     filename = 'tmp/fake-post.md'
-    author = create(:user)
-    content = <<-eof.gsub(/^ +/, '')
-      ---
-      title: This is the post title
-      author: #{author.name}
-      tags: General, Development
-      ---
-
+    author ||= create(:user)
+    mtime ||= Time.now
+    title ||= "This is the post title"
+    tags ||= "General, Development"
+    body ||= <<-eof.gsub(/^ +/, '')
       # A title
 
       A paragraph
     eof
 
-    File.open(filename, 'w') { |f| f.write(content) }
+    full_content ||= <<-eof.gsub(/^ +/, '')
+      ---
+      title: #{title}
+      author: #{author.name}
+      tags: #{tags}
+      ---
+      #{body}
+    eof
+
+    File.open(filename, 'w') { |f| f.write(full_content) }
+    FileUtils.touch(filename, mtime: mtime.to_time)
     filename
   end
 
@@ -41,10 +48,10 @@ describe PostFile do
     it 'includes the correct content' do
       post_file = PostFile.import(mock_post_file)
 
-      content = post_file.data[:content]
+      body = post_file.data[:body]
 
-      expect(content).to include('# A title')
-      expect(content).to include('A paragraph')
+      expect(body).to include('# A title')
+      expect(body).to include('A paragraph')
     end
   end
 
@@ -56,6 +63,118 @@ describe PostFile do
 
       expect(body).not_to include('---')
       expect(body).not_to include('This is the post title')
+    end
+  end
+
+  context '.import' do
+    it 'touches the post_file model if the file is updated' do
+      file = mock_post_file(mtime: 1.hour.ago)
+      post_file = PostFile.import(file)
+      old_timestamp = post_file.reload.updated_at
+
+      file = mock_post_file
+      new_post_file = PostFile.import(file)
+
+      expect(new_post_file).to eq(post_file)
+      expect(new_post_file.updated_at).to be > old_timestamp
+    end
+
+    it 'creates a post' do
+      post_file = PostFile.import(mock_post_file)
+
+      expect(post_file.post).to be_a(Post)
+      expect(post_file.post).to be_valid
+    end
+
+    it 'updates the post when importing the same file' do
+      old_post_file = PostFile.import(mock_post_file(mtime: 2.hours.ago))
+
+      new_post_file = PostFile.import(mock_post_file(mtime: 1.hour.ago))
+
+      expect(new_post_file.post).to eq(old_post_file.post)
+    end
+
+    it 'keeps track of when the file was last updated' do
+      old_post_file = PostFile.import(mock_post_file(mtime: 2.hours.ago))
+      old_timestamp = old_post_file.last_file_timestamp
+
+      new_post_file = PostFile.import(mock_post_file(mtime: 1.hour.ago))
+
+      expect(new_post_file.last_file_timestamp).to be > old_timestamp
+    end
+  end
+
+  context 'Generated post' do
+    it 'has the correct author' do
+      post_file = PostFile.import(mock_post_file)
+
+      author = post_file.data[:author]
+
+      expect(post_file.post.author).to eq(author)
+    end
+
+    it 'has the correct title' do
+      post_file = PostFile.import(mock_post_file)
+
+      title = post_file.data[:title]
+
+      expect(post_file.post.title).to eq(title)
+    end
+
+    it 'has the correct body' do
+      post_file = PostFile.import(mock_post_file)
+
+      body = post_file.data[:body]
+
+      expect(post_file.post.body).to eq(body)
+    end
+
+    it 'has the correct tag list' do
+      post_file = PostFile.import(mock_post_file)
+
+      tag_list = post_file.data[:tag_list]
+
+      expect(post_file.post.tag_list.join(', ')).to eq(tag_list)
+    end
+  end
+
+  context '#valid?' do
+    it 'prevents posts without title' do
+      post_file = PostFile.import(mock_post_file(title: ''))
+
+      expect(post_file).not_to be_valid
+    end
+
+    it 'prevents posts with non-existing author' do
+      fake_author = build(:user, first_name: 'Barack', last_name: 'Obama')
+
+      post_file = PostFile.import(mock_post_file(author: fake_author))
+
+      expect(post_file).not_to be_valid
+    end
+
+    it 'prevents posts with blank body' do
+      post_file = PostFile.import(mock_post_file(body: "   \n\n  "))
+
+      expect(post_file).not_to be_valid
+    end
+
+    it 'prevents posts without tags' do
+      post_file = PostFile.import(mock_post_file(tags: ' '))
+
+      expect(post_file).not_to be_valid
+    end
+
+    it 'prevents posts without a primary tag' do
+      post_file = PostFile.import(mock_post_file(tags: 'unimportant, stuff'))
+
+      expect(post_file).not_to be_valid
+    end
+
+    it 'does not create a post when file is invalid' do
+      expect {
+        PostFile.import(mock_post_file(title: ''))
+      }.not_to change { Post.count }
     end
   end
 end

--- a/spec/models/post_file_spec.rb
+++ b/spec/models/post_file_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe PostFile do
+
+  def mock_post_file(date: nil)
+    filename = 'tmp/fake-post.md'
+    author = create(:user)
+    content = <<-eof.gsub(/^ +/, '')
+      ---
+      title: This is the post title
+      author: #{author.name}
+      tags: General, Development
+      ---
+
+      # A title
+
+      A paragraph
+    eof
+
+    File.open(filename, 'w') { |f| f.write(content) }
+    filename
+  end
+
+  context '#data' do
+    it 'includes the post title' do
+      post_file = PostFile.import(mock_post_file)
+
+      title = post_file.data[:title]
+
+      expect(title).to eq('This is the post title')
+    end
+
+    it 'finds the correct author' do
+      post_file = PostFile.import(mock_post_file)
+
+      author = post_file.data[:author]
+
+      expect(author).to be_a(User)
+    end
+
+    it 'includes the correct content' do
+      post_file = PostFile.import(mock_post_file)
+
+      content = post_file.data[:content]
+
+      expect(content).to include('# A title')
+      expect(content).to include('A paragraph')
+    end
+  end
+
+  context '#body' do
+    it 'does not include yaml front matter' do
+      post_file = PostFile.import(mock_post_file)
+
+      body = post_file.body
+
+      expect(body).not_to include('---')
+      expect(body).not_to include('This is the post title')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe User do
+  context '.from_full_name' do
+    it 'finds a user from an exact name' do
+      first_name, last_name = %w(Miguel Palhas)
+      user = create(:user, first_name: first_name, last_name: last_name)
+      search_name = "#{first_name} #{last_name}"
+
+      found_user = User.from_full_name(search_name)
+
+      expect(found_user).to eq user
+    end
+
+    it 'finds a user from a lower cased name' do
+      first_name, last_name = %w(Miguel Palhas)
+      user = create(:user, first_name: first_name, last_name: last_name)
+      search_name = "#{first_name} #{last_name}".downcase
+
+      found_user = User.from_full_name(search_name)
+
+      expect(found_user).to eq user
+    end
+
+    it 'finds nothing if the name is wrong' do
+      first_name, last_name = %w(Miguel Palhas)
+      create(:user, first_name: first_name, last_name: last_name)
+
+      found_user = User.from_full_name('something else')
+
+      expect(found_user).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
**NOTE:** This is a working in progress, but I'm opening it now to allow discussing while I keep testing this further

This change allows us to write posts as we would in a Jekyll blog, by creating a markdown file, and simply commiting it

Why:
- It's something some of us wanted for some time (me and @zamith at least).
- It allows us to publish posts using our usual work flow (commit, pull request & code review), instead of going through the blog's admin UI.
- It makes posts open source, so anyone can contribute with changes (such as @vis-kid, who asked about this a few days ago)
- I wanted to.

All this is opt-in. Posts can still be written the old way (for non-developers and posts we want to keep secret until publishing)

Missing stuff:
- [ ] Force markdown files to start with a timestamp, to keep order consistent
- [ ] Have a way to publish posts (i.e. add a `published` field to the YAML front matter)
- [ ] Preprocess any image tags found in the content, and fetch the images to our own server.
- [ ] Trigger the rake task on every deploy

I'll probably take this chance to migrate our assets to Amazon S3
