### PR TITLE
Adds twitter link to author bio

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,5 @@
+module ApplicationHelper
+  def twitter_url(username: nil)
+    "https://twitter.com/#{username.presence || 'subvisual'}"
+  end
+end

--- a/app/views/posts/_author_bio.slim
+++ b/app/views/posts/_author_bio.slim
@@ -10,6 +10,6 @@
     .ContentFormatter.ContentFormatter--centerHorizontallyThenLeft
       h2.AuthorHeading
         ' About
-        span.AuthorHeading-name = author.name
+        = link_to author.name, twitter_url(username: post.author.twitter_handle), class: 'AuthorHeading-name', target: '_blank'
       .u-xSmallMargin
       .AltText = author.bio


### PR DESCRIPTION
We don't have a twitter link for authors anywhere.

As suggested by @lauraesteves, this adds a twitter link to the author's name in the bio below each post