### PR TITLE
Force links in a post to open in a new tab

### DIFF
--- a/app/subvisual-blog/services/post_processor.rb
+++ b/app/subvisual-blog/services/post_processor.rb
@@ -30,7 +30,9 @@ module Services
       include Rouge::Plugins::Redcarpet
 
       def postprocess(full_doc)
-        full_doc.gsub(/<p><img/, '<p class="Post-imageWrapper"><img')
+        full_doc.
+          gsub(/<p><img/, '<p class="Post-imageWrapper"><img').
+          gsub(/<a /, '<a target="_blank" ')
       end
     end
   end

--- a/spec/services/post_processor_spec.rb
+++ b/spec/services/post_processor_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Services::PostProcessor do
 
       post.processed_body.should have_tag('pre', with: { class: 'highlight' })
     end
+
+    it 'creates links targeting a new browser tab' do
+      post = build :post, body: markdown_code_block
+
+      Services::PostProcessor.new(post).process
+
+      post.processed_body.should have_tag('a', with: { target: '_blank', href: 'link' })
+    end
   end
 end
 
@@ -43,5 +51,7 @@ def markdown_code_block
 def x
 end
 ```
+
+[text](link)
   '''
 end


### PR DESCRIPTION
Why:

* Most links in our posts go to external websites, and not our own. So I
believe the default should be to open them in a new tab