### PR TITLE
Allow the post title to have HTML markup

### DIFF
--- a/app/views/posts/_post_hero.slim
+++ b/app/views/posts/_post_hero.slim
@@ -13,7 +13,7 @@
 - content_for :hero
   .PostWidthConstrainer.PostWidthConstrainer--title
     h1.PostHeading.PostHeading--large class="#{content_for(:post_heading_class)}"
-      = post.title
+      = raw post.title
     .PostInfo class="#{content_for(:post_info_class)}"
       .u-smallThenDefaultMargin
       .PostInfo-author


### PR DESCRIPTION
Why:

* I need to control where the title breaks

This change addresses the need by:

* Allowing to submit HTML tags as part of the title of post, which are
  then rendered as part of the DOM and not as text.