### PR TITLE
Improves style for both block and inline code

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails server
+worker: elasticsearch

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -16,7 +16,8 @@ $NavLogo-desktop-mono:    image-path('blue/subvisual_logo_mono_with_name.svg');
 
 @font-face {
   font-family: 'SourceCodePro-Regular';
-  src: url('SourceCodePro-Regular.ttf') format('truetype'), url('SourceCodePro-Regular.woff') format('woff');
+  src: url('SourceCodePro-Regular.ttf') format('truetype'),
+       url('SourceCodePro-Regular.woff') format('woff');
 }
 
 $Theme-font-sizes-extra: (

--- a/app/assets/stylesheets/components/_post.scss
+++ b/app/assets/stylesheets/components/_post.scss
@@ -2,6 +2,8 @@ $Post-default-max-width: 600px + $Theme-spacing-small * 2;
 $Post-code-max-width: 600px + $Theme-spacing-small * 2;
 $Post-img-max-width: 800px + $Theme-spacing-small * 2;
 
+$Post-inlineCodeBgColor: rgba(0, 0, 0, 0.04);
+
 @mixin PostMaxWidth($width: $Post-default-max-width) {
   // scss-lint:disable ImportantRule
   display: block;
@@ -96,6 +98,18 @@ $Post-img-max-width: 800px + $Theme-spacing-small * 2;
     font-family: 'SourceCodePro-Regular';
   }
 
+  code {
+    padding: 0.2em;
+    margin: 0;
+
+    background-color: $Post-inlineCodeBgColor;
+
+    border-radius: 3px;
+
+    font-family: 'SourceCodePro-Regular';
+    font-size: 85%;
+  }
+
   .highlight { // scss-lint:disable SelectorFormat
     pre,
     code {
@@ -106,6 +120,15 @@ $Post-img-max-width: 800px + $Theme-spacing-small * 2;
 
       white-space: pre-wrap;
       word-wrap: break-word;
+    }
+
+    code {
+      @include font-properties(code, base, $Theme-font-sizes-extra);
+
+      padding-top: 0;
+      padding-bottom: 0;
+
+      background-color: transparent;
     }
   }
 

--- a/bin/server
+++ b/bin/server
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-rails server
+bundle exec foreman start

--- a/bin/setup
+++ b/bin/setup
@@ -7,3 +7,4 @@ fi
 bundle install
 bundle exec rake db:create
 bundle exec rake db:setup
+bower install


### PR DESCRIPTION
Inline code was not styled and at least my browser, because chrome is setting the `font-family` for the `code` tag, the block code was using the default monospace font.

Before:

<img width="683" alt="screen shot 2016-03-15 at 4 47 23" src="https://cloud.githubusercontent.com/assets/166304/13786089/0ba81ff0-eace-11e5-99b5-d8521eebef92.png">

After:

<img width="620" alt="screen shot 2016-03-15 at 4 47 04" src="https://cloud.githubusercontent.com/assets/166304/13786097/133616be-eace-11e5-9496-1c5599992a04.png">

