### PR TITLE
Strip title of HTML tags unless needed

### DIFF
--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -1,7 +1,7 @@
 class PostDecorator < Draper::Decorator
   decorates_association :category
   decorates_association :author
-  delegate :title, :published?, :published_at, :created_at,
+  delegate :title, :raw_title, :published?, :published_at, :created_at,
     :updated_at, :persisted?, :id, :tag_list, :related_by_author,
     :related_by_tags, :secondary_tags, :hero, :hero?
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,6 +9,8 @@ class Post < ActiveRecord::Base
   include Elasticsearch::Model::Callbacks
   index_name [Rails.env, model_name.collection.gsub(%r{/}, '-')].join('_')
 
+  include ActionView::Helpers::SanitizeHelper
+
   default_scope  { order('published_at DESC') }
 
   belongs_to :author, class_name: 'User'
@@ -33,6 +35,14 @@ class Post < ActiveRecord::Base
 
   def to_param
     "#{id} #{title}".parameterize
+  end
+
+  def title
+    sanitize(read_attribute(:title), tags: [])
+  end
+
+  def raw_title
+    read_attribute(:title)
   end
 
   def published?

--- a/app/views/admin/posts/_form.slim
+++ b/app/views/admin/posts/_form.slim
@@ -53,7 +53,7 @@
 
     .u-smallMargin
 
-    = f.text_field :title, placeholder: 'Title', class: 'TitleInput', autocomplete: :off
+    = text_field_tag :title, post.raw_title, name: "post[title]", placeholder: 'Title', class: 'TitleInput', autocomplete: :off
 
   .u-smallMargin
 

--- a/app/views/posts/_post_hero.slim
+++ b/app/views/posts/_post_hero.slim
@@ -13,7 +13,7 @@
 - content_for :hero
   .PostWidthConstrainer.PostWidthConstrainer--title
     h1.PostHeading.PostHeading--large class="#{content_for(:post_heading_class)}"
-      = raw post.title
+      = raw post.raw_title
     .PostInfo class="#{content_for(:post_info_class)}"
       .u-smallThenDefaultMargin
       .PostInfo-author

--- a/app/views/posts/_post_intro.slim
+++ b/app/views/posts/_post_intro.slim
@@ -2,7 +2,7 @@
 
 .Post
   .PostWidthConstrainer
-    h1.PostHeading = link_to sanitize(post.title, tags: []), post_path(post), class: 'PostHeading-link'
+    h1.PostHeading = link_to post.title, post_path(post), class: 'PostHeading-link'
   .u-smallMargin
   .Post-body
     = post.processed_intro

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -11,6 +11,22 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  context '#title' do
+    it 'returns a sanitized title without HTML tags' do
+      post = Post.new(title: 'Title<br> with tags')
+
+      expect(post.title).to eq('Title with tags')
+    end
+  end
+
+  context '#raw_title' do
+    it 'returns the raw title, with HTML tags' do
+      post = Post.new(title: 'Title<br> with tags')
+
+      expect(post.raw_title).to eq('Title<br> with tags')
+    end
+  end
+
   context '.published' do
     it 'returns only posts that are published' do
       create_list(:post, 2)


### PR DESCRIPTION
Why:

* The title is being used in a lot of places from constructing the URL
  to metatags, and we want to have the clean version without HTML tags

This change addresses the need by:

* Overriding the `title` method to return a clean (no HTML) version of
  the title
* Add a `raw_title` that can be used when we need to get the HTML tags,
  which at this point is only the post hero, when showing it.