### PR TITLE
Fixes OAuth first time sign in

### DIFF
--- a/app/models/oauth_user.rb
+++ b/app/models/oauth_user.rb
@@ -8,7 +8,7 @@ class OauthUser
   def headquarters(email)
     data = hq_user_data(email)
     User.where(hq_id: data['id']).first_or_initialize.tap do |user|
-      user.update_attributes(data.slice(:email, :name))
+      user.update_attributes(data.slice('email', 'name'))
     end
   end
 


### PR DESCRIPTION
When a new user signs in for the first time using HQ, oauth user creation fails.

This happens because `OauthUser#headquarters` is slicing a hash using symbols as
keys, instead of Strings.