### PR TITLE
Adds pry-remote

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ end
 group :development, :test do
   gem 'capybara'
   gem 'pry-rails'
+  gem 'pry-remote'
   gem 'rspec-rails'
   gem 'scss_lint', require: false
   gem 'rb-readline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,9 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     puma (2.11.3)
       rack (>= 1.1, < 2.0)
     quiet_assets (1.1.0)
@@ -537,6 +540,7 @@ DEPENDENCIES
   pg
   pippi
   pry-rails
+  pry-remote
   puma
   quiet_assets
   rack-mini-profiler
@@ -562,4 +566,4 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
When debugging #122 , there were some issues due to the lack of `pry-remote`.