### PR TITLE
Add a JSON endpoint for the most recent posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.4"
 
+gem "active_model_serializers", "~> 0.10.0"
 gem "acts-as-taggable-on"
 gem "analytics-ruby", require: "segment/analytics"
 gem "autoprefixer-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.2)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
     activejob (4.2.4)
       activesupport (= 4.2.4)
       globalid (>= 0.3.0)
@@ -304,6 +309,8 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     jwt (1.5.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -498,6 +505,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   acts-as-taggable-on
   airbrake
   analytics-ruby

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,10 @@ class PostsController < ApplicationController
 
   def index
     @posts = Post.recent.published.includes(:tags)
+    respond_to do |format|
+      format.html
+      format.json { render json: @posts }
+    end
   end
 
   def search

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,0 +1,5 @@
+class PostSerializer < ActiveModel::Serializer
+  attributes :id, :title, :tag_list
+  attribute :processed_intro, key: :body
+  belongs_to :author
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,14 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :email, :first_name, :last_name,
+    :twitter_handle, :photo_url
+
+  def photo_url
+    ActionController::Base.helpers.image_url(photo_name)
+  end
+
+  private
+
+  def photo_name
+    "authors/#{object.name.downcase.parameterize}_50.png"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ SubvisualBlog::Application.routes.draw do
   get '/blog/auth/:provider/callback', to: 'sessions#create'
 
   scope '/blog' do
+    constraints format: :json do
+      resources :posts, only: %i(index)
+    end
+
     constraints format: :html do
       root to: "posts#index"
 


### PR DESCRIPTION
Why:

This change creates a JSON endpoint for the most recent blog posts.

We need to render the most recent posts on the homepage. The homepage
is a static page, built on middleman, and adding a back-end to list blog
posts seems overkill. The idea is to make a request on the browser for the
most recent posts and add them dynamically to the homepage.

Notes:

I'm not very confident about duplicating information about the picture's
name, I guess on the model would make more sense to avoid duplication.
But on the other hand, it would add presentation details to the model.

This change addresses the need by:

* Adding AMS.
* Adding serializers for posts and users.
* Adding a JSON endpoint.