### PR TITLE
Removing elasticsearch in favor of PostgreSQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,8 @@ gem "coffee-rails", "~> 4.0.0"
 gem "clearance", "1.10.1"
 gem "dotenv-rails"
 gem "draper", "~> 1.3"
-gem "elasticsearch-model"
-gem "elasticsearch-rails"
 gem "fog"
+gem "foreman"
 gem "headquarters", github: "subvisual/headquarters-ruby"
 gem "jquery-rails"
 gem "jquery-ui-rails"
@@ -23,6 +22,7 @@ gem "octokit"
 gem "omniauth"
 gem "omniauth-headquarters", github: "subvisual/omniauth-headquarters"
 gem "pg"
+gem "pg_search"
 gem "puma"
 gem "redcarpet", require: false
 gem "rollbar"
@@ -55,7 +55,6 @@ group :test do
   gem "codacy-coverage", require: false
   gem "rest-client"
   gem "database_cleaner", "1.0.1", require: false
-  gem "elasticsearch-extensions"
   gem "factory_girl_rails", "~> 4.0", require: false
   gem "faker", require: false
   gem "simplecov", require: false
@@ -71,10 +70,6 @@ group :development, :test do
   gem "rspec-rails"
   gem "scss_lint", require: false
   gem "rb-readline"
-end
-
-group :production do
-  gem "foreman"
 end
 
 group :deploy do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
       activerecord (>= 3.2, < 5)
     addressable (2.3.8)
     analytics-ruby (2.0.12)
-    ansi (1.5.0)
     arel (6.0.3)
     ast (2.3.0)
     autoprefixer-rails (5.1.11)
@@ -154,22 +153,6 @@ GEM
       activemodel (>= 3.0)
       activesupport (>= 3.0)
       request_store (~> 1.0)
-    elasticsearch (1.0.8)
-      elasticsearch-api (= 1.0.7)
-      elasticsearch-transport (= 1.0.7)
-    elasticsearch-api (1.0.7)
-      multi_json
-    elasticsearch-extensions (0.0.18)
-      ansi
-      ruby-prof
-    elasticsearch-model (0.1.7)
-      activesupport (> 3)
-      elasticsearch (> 0.4)
-      hashie
-    elasticsearch-rails (0.1.7)
-    elasticsearch-transport (1.0.7)
-      faraday
-      multi_json
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
@@ -348,6 +331,10 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.2)
+    pg_search (1.0.6)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
+      arel
     pippi (0.0.14)
     powerpack (0.1.1)
     pry (0.10.1)
@@ -437,7 +424,6 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 0.3)
-    ruby-prof (0.15.8)
     ruby-progressbar (1.8.1)
     sass (3.4.14)
     sass-rails (5.0.3)
@@ -527,9 +513,6 @@ DEPENDENCIES
   database_cleaner (= 1.0.1)
   dotenv-rails
   draper (~> 1.3)
-  elasticsearch-extensions
-  elasticsearch-model
-  elasticsearch-rails
   factory_girl_rails (~> 4.0)
   faker
   fog
@@ -543,6 +526,7 @@ DEPENDENCIES
   omniauth
   omniauth-headquarters!
   pg
+  pg_search
   pippi
   pry-rails
   pry-remote

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec rails server
-worker: elasticsearch

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Our blog. Live @ [https://subvisual.co/blog](https://subvisual.co/blog)
 
 ## Dependencies
 
-  * **elasticsearch**: It's up to the developer to ensure this service is running. Errors may occur during development/test if it isn't
+  * **PG unaccent**: This extension is used to allow case-insensitive searches
   * **memcached (optional)**: Should not be necessary during development, unless you're interesting in testing the cache system
 
 ## Setup

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -50,7 +50,7 @@ class Admin::PostsController < Admin::ApplicationController
   def unpublish
     @post = Post.find params[:post_id]
     @post.update_attribute :published_at, nil
-    redirect_to admin_post_path(@post), alert: "Post successfully unpublished"
+    redirect_to edit_admin_post_path(@post), alert: "Post successfully unpublished"
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
   def search
     @query = search_params[:q] || ""
     @posts = begin
-      Post.search(@query, size: 20).records.published
+      PgSearch.multisearch(@query).limit(20).map(&:searchable)
     rescue StandardError
       Post.none
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,13 +1,13 @@
-require "elasticsearch/model"
-
 class Post < ActiveRecord::Base
   POSTS_LIMIT = 10
   MIN_INTRO_SIZE = 140
   PRIMARY_TAGS = %i(development design community general)
 
-  include Elasticsearch::Model
-  include Elasticsearch::Model::Callbacks
-  index_name [Rails.env, model_name.collection.gsub(%r{/}, "-")].join("_")
+  include PgSearch
+  multisearchable(
+    against: %i(title processed_body author_name tags),
+    if: :published?,
+  )
 
   include ActionView::Helpers::SanitizeHelper
 

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,5 +1,0 @@
-if Rails.env.production?
-  # :nocov:
-  Post.import
-  # :nocov:
-end

--- a/config/initializers/pg_search.rb
+++ b/config/initializers/pg_search.rb
@@ -1,0 +1,3 @@
+PgSearch.multisearch_options = {
+  ignoring: :accents,
+}

--- a/db/migrate/20160822173713_create_pg_search_documents.rb
+++ b/db/migrate/20160822173713_create_pg_search_documents.rb
@@ -1,0 +1,17 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration
+  def self.up
+    say_with_time("Creating table for pg_search multisearch") do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.belongs_to :searchable, :polymorphic => true, :index => true
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def self.down
+    say_with_time("Dropping table for pg_search multisearch") do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/db/migrate/20160822175235_create_extension_unaccent.rb
+++ b/db/migrate/20160822175235_create_extension_unaccent.rb
@@ -1,0 +1,5 @@
+class CreateExtensionUnaccent < ActiveRecord::Migration
+  def change
+    enable_extension "unaccent"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151012150004) do
+ActiveRecord::Schema.define(version: 20160822175235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
+
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text     "content"
+    t.integer  "searchable_id"
+    t.string   "searchable_type"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "pg_search_documents", ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id", using: :btree
 
   create_table "post_files", force: :cascade do |t|
     t.string   "filename",            null: false

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,10 @@
+namespace :data do
+  namespace :search do
+    task rebuild: :environment do
+      puts "Rebuilding search index for posts"
+      PgSearch::Document.delete_all(searchable_type: "Post")
+      PgSearch::Multisearch.rebuild(Post)
+      puts "### DONE ###"
+    end
+  end
+end


### PR DESCRIPTION
We rarely use our blog's search, and it is still badly configured
(searches often don't work as expected). Elasticsearch also uses too
much resources, and is an extra dependency we have to maintain

PgSearch achieves the same result with good performance (again,
there's not much usage here) and it seems to be easily configurable

PS: This is a WIP, as I still have to test how the installation of the `unaccent` extension works on the server