### PR TITLE
Change attributes serializers

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,5 +1,4 @@
 class PostSerializer < ActiveModel::Serializer
-  attributes :id, :title, :tag_list
-  attribute :processed_intro, key: :body
+  attributes :id, :title, :tag_list, :processed_intro
   belongs_to :author
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :first_name, :last_name,
+  attributes :id, :first_name, :last_name,
     :twitter_handle, :photo_url
 
   def photo_url


### PR DESCRIPTION
Why:

This change will remove the alias processed_body => body in the posts
serializer in order to avoid confusion in the future.

I'm also removing the email from the user serializer, it's not
necessary.

This change addresses the need by:

* Updating serializers.