### PR TITLE
Adds dedicate hero model (part 2 of 2)

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,7 +16,7 @@ class Post < ActiveRecord::Base
 
   belongs_to :author, class_name: "User"
   belongs_to :category
-  has_one :hero, class_name: "PostImage"
+  has_one :hero
   acts_as_taggable
 
   accepts_nested_attributes_for :hero

--- a/lib/tasks/data/migrate.rake
+++ b/lib/tasks/data/migrate.rake
@@ -22,5 +22,17 @@ namespace :data do
 
       puts "### DONE ###"
     end
+
+    task destroy_old_post_images: :environment do
+      ensure_date(Date.new(2016, 8, 30))
+
+      puts "Deleting old PostImage records migrated into Hero"
+
+      ActiveRecord::Base.transaction do
+        PostImage.where("post_id IS NOT NULL").destroy_all
+      end
+
+      puts "### DONE ###"
+    end
   end
 end


### PR DESCRIPTION
This is a follow-up on
https://github.com/subvisual/blog.subvisual.co/pull/132

The Hero model was successfully imported in production.
In this PR, I simply switch the relation to use the new one, and add a
new data migration task to remove previous PostImages records that
are now useless.