### PR TITLE
Changes default branch name so as not to depend on post title

### DIFF
--- a/app/models/github/adapter.rb
+++ b/app/models/github/adapter.rb
@@ -32,7 +32,17 @@ class Github::Adapter
   end
 
   def branch_sha
+    updated_branch_sha || deprecated_branch_sha
+  end
+
+  def updated_branch_sha
     @_branch_sha ||= client.ref(repo, "heads/#{branch_name}").object.sha
+  rescue Octokit::NotFound
+    false
+  end
+
+  def deprecated_branch_sha
+    @_branch_sha ||= client.ref(repo, "heads/#{deprecated_branch_name}").object.sha
   rescue Octokit::NotFound
     false
   end
@@ -59,6 +69,10 @@ class Github::Adapter
   end
 
   def branch_name
+    @_branch_name ||= "#{post.author.name.parameterize}-#{post.id}"
+  end
+
+  def deprecated_branch_name
     @_branch_name ||= post.title.parameterize
   end
 


### PR DESCRIPTION
Whenever a title changes, it's corresponding PR is no longer found, and
a new one is created.
This changes the behaviour so that the branch name no longer depends on
the title, and on the author's name and post ID instead, since those are
not expected to change.

The previous behaviour was deprecated and not removed, so that existing
PRs still work
