### PR TITLE
Converts all h1 headings to h2 within the post body

### DIFF
--- a/app/assets/stylesheets/components/_post.scss
+++ b/app/assets/stylesheets/components/_post.scss
@@ -32,24 +32,24 @@ $Post-inlineCodeBgColor: rgba(0, 0, 0, 0.04);
     padding-left: $Theme-spacing-small;
   }
 
-  h1,
   h2,
-  h3 {
+  h3,
+  h4 {
     padding-top: $Theme-spacing-small;
     padding-bottom: $Theme-spacing-small;
   }
 
-  h1:not(:first-child) {
+  h2:not(:first-child) {
     @include font-properties(heading, veryLarge, $Theme-font-sizes-extra);
 
     margin-top: $Theme-spacing-small;
   }
 
-  h2 {
+  h3 {
     @include font-properties(heading, large, $Theme-font-sizes-extra);
   }
 
-  h3 {
+  h4 {
     @include font-properties(heading, base, $Theme-font-sizes-extra);
   }
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ActiveRecord::Base
   POSTS_LIMIT = 10
   MIN_INTRO_SIZE = 140
   PRIMARY_TAGS = %i(development design community general)
+  MAIN_HEADING_REGEX = /^#[^#]/
 
   include PgSearch
   multisearchable(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,17 +1,17 @@
 users = [
-  { first_name: 'Roberto', last_name: 'Machado', email: 'roberto@groupbuddies.com', twitter_handle: 'rmdgb' },
-  { first_name: 'Miguel',  last_name: 'Palhas',  email: 'mpalhas@groupbuddies.com',    twitter_handle: 'naps62' },
-  { first_name: 'Luis',    last_name: 'Zamith',  email: 'zamith@groupbuddies.com',     twitter_handle: 'zamith' },
-  { first_name: 'João',    last_name: 'Ferreira', email: 'joao@groupbuddies.com',      twitter_handle: 'jferreiradzn' },
-  { first_name: 'Ronaldo', last_name: 'Sousa',    email: 'ronaldo@groupbuddies.com',   twitter_handle: 'ronaldofsousa' },
-  { first_name: 'Gabriel', last_name: 'Poça',     email: 'gabriel@groupbuddies.com',   twitter_handle: 'gabrielgpoca' },
-  { first_name: 'Bruno',   last_name: 'Azevedo',  email: 'bruno@groupbuddies.com' }
+  { first_name: "Roberto", last_name: "Machado", email: "roberto@subvisual.co", twitter_handle: "rmdgb" },
+  { first_name: "Miguel",  last_name: "Palhas",  email: "miguel@subvisual.co",    twitter_handle: "naps62" },
+  { first_name: "Luis",    last_name: "Zamith",  email: "zamith@subvisual.co",     twitter_handle: "zamith" },
+  { first_name: "João",    last_name: "Ferreira", email: "joao@subvisual.co",      twitter_handle: "jferreiradzn" },
+  { first_name: "Ronaldo", last_name: "Sousa",    email: "ronaldo@subvisual.co",   twitter_handle: "ronaldofsousa" },
+  { first_name: "Gabriel", last_name: "Poça",     email: "gabriel@subvisual.co",   twitter_handle: "gabrielgpoca" },
+  { first_name: "Bruno",   last_name: "Azevedo",  email: "bruno@subvisual.co" }
 ]
 
 users.each do |user_data|
   User.where(user_data).first_or_initialize.tap do |user|
-    user.password = user.email.split('@').first
-    user.bio = 'Nothing to say yet...'
+    user.password = user.email.split("@").first
+    user.bio = "Nothing to say yet..."
     user.save!
   end
 end

--- a/lib/tasks/data/migrate.rake
+++ b/lib/tasks/data/migrate.rake
@@ -54,5 +54,21 @@ namespace :data do
         end
       end
     end
+
+    task remove_main_headings: :environment do
+      puts "Downgrading all post's h1 tags to h2, and so on..."
+
+      ActiveRecord::Base.transaction do
+        Post.find_each do |post|
+          next unless post.body =~ /^#[^#]/
+
+          updated_body = post.body.gsub(/^#/, "##")
+
+          post.update body: updated_body
+        end
+      end
+
+      puts "Done!"
+    end
   end
 end

--- a/spec/lib/tasks/data/migrate_spec.rb
+++ b/spec/lib/tasks/data/migrate_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+RSpec.describe "data:migrate:remove_main_headings" do
+  include_context "rake"
+
+  it "migrates posts with main headings" do
+    post = create :post, body: "# title"
+
+    subject.invoke
+
+    expect(post.reload.body).to eq "## title"
+  end
+
+  it "does not migrates posts without main headings" do
+    post = create :post, body: "## title"
+
+    subject.invoke
+
+    expect(post.reload.body).to eq "## title"
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  context "#valid?" do
+    it "does not allow main"
+  end
+
   context "#published?" do
     it "returns false for an unpublished post" do
       post = create :post
@@ -47,6 +51,32 @@ RSpec.describe Post, type: :model do
       post = create :published_post
 
       post.should be_published
+    end
+  end
+
+  context "::MAIN_HEADING_REGEX" do
+    it "catches posts with main heading tags" do
+      post = build :post, body: "# title"
+
+      match = post.body.match(Post::MAIN_HEADING_REGEX)
+
+      expect(match).to be
+    end
+
+    it "catches posts with main headings not on the first line" do
+      post = build :post, body: "text\n\n# title"
+
+      match = post.body.match(Post::MAIN_HEADING_REGEX)
+
+      expect(match).to be
+    end
+
+    it "does not catch posts with secondary headings" do
+      post = build :post, body: "## title"
+
+      match = post.body.match(Post::MAIN_HEADING_REGEX)
+
+      expect(match).not_to be
     end
   end
 end

--- a/spec/services/post_processor_spec.rb
+++ b/spec/services/post_processor_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Services::PostProcessor do
     end
 
     it "parses markdown" do
-      post = build :post, body: "# title"
+      post = build :post, body: "## title"
 
       Services::PostProcessor.new(post).process
 
-      post.processed_body.should have_tag "h1"
+      post.processed_body.should have_tag "h2"
     end
 
     it "parses the first paragraph" do
@@ -72,6 +72,20 @@ def markdown_table
 |---|---|
 | 1 | x |
 | 2 | o |
+  '""
+end
+
+def body_with_main_heading
+  ""'
+# Main heading
+## Secondary heading
+  '""
+end
+
+def body_without_main_heading
+  ""'
+## Main heading
+### Secondary heading
   '""
 end
 # rubocop:enable Lint/ImplicitStringConcatenation

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -1,0 +1,23 @@
+require "rake"
+
+RSpec.shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(':')[0..-2].join('/')}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $LOADED_FEATURES.reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(
+      task_path,
+      [Rails.root.to_s],
+      loaded_files_excluding_current_rake_file,
+    )
+
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
This is a huge accessibility issue in our blog.
All of our post pages contain multiple h1 tags. Only the main post title
should exist.
It follows that the post's markdown content should only contain h2 tags
and below.

This adds a rake task that migrates all posts to remove their main
headings, in favor of secondary ones.

So, if a post has an `h1` tag, it becomes an `h2`, `h2` becomes `h3` and
so on.
If a post already doesn't have `h1` tags, it won't be touched

After deploying, I'll run the rake task to migrate existing posts.

A latter PR will add validations to prevent new posts from having main
headings