### PR TITLE
Update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2015 Subvisual
+Copyright (c) 2014-2017 Subvisual
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/views/layouts/_footer.slim
+++ b/app/views/layouts/_footer.slim
@@ -2,7 +2,7 @@
   .Footer-credits
     span.Footer-handcrafted Handcrafted by
     span.Footer-subvisual SUBVISUAL
-    span.Footer-copyright © 2015 Copyright by Subvisual
+    span.Footer-copyright © #{Date.today.year} Copyright by Subvisual
   = link_to 'https://subvisual.co/hire-us', class: 'Footer-work'
     span.Footer-interested Interested in our services?
     .Footer-workText


### PR DESCRIPTION
Why:

* The copyright year is outdated in both the footer and the license.

This change addresses the issue by:

* Refactoring the footer to dynamically change the copyright year;
* Updating the copyright year in the license text.